### PR TITLE
Minor changes for external uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,98 +10,14 @@ STATIC ?= false
 # ${lvgui.version}-${lvgl.version}
 VERSION = 0.1-6.1.2
 
-LVGL_ENV_SIMULATOR ?= 1
-WARNING_FLAGS ?= \
-	-Wall \
-	-Wclobbered \
-	-Wdeprecated \
-	-Wdouble-promotion \
-	-Wempty-body \
-	-Werror \
-	-Wextra \
-	-Wformat-security \
-	-Wmaybe-uninitialized \
-	-Wmissing-prototypes \
-	-Wmultichar \
-	-Wno-cast-qual \
-	-Wno-discarded-qualifiers \
-	-Wno-error=cpp \
-	-Wno-error=missing-prototypes \
-	-Wno-error=pedantic \
-	-Wno-error=strict-prototypes \
-	-Wno-format-nonliteral \
-	-Wno-ignored-qualifiers \
-	-Wno-missing-field-initializers \
-	-Wno-sign-compare \
-	-Wno-switch-default \
-	-Wno-unused-function \
-	-Wno-unused-parameter \
-	-Wno-unused-value \
-	-Wpointer-arith \
-	-Wreturn-type \
-	-Wshift-negative-value \
-	-Wsizeof-pointer-memaccess \
-	-Wstack-usage=4096 \
-	-Wswitch-enum \
-	-Wtype-limits \
-	-Wundef \
-	-Wuninitialized \
-	-Wunreachable-code \
-	-fno-strict-aliasing \
-
-# Fails on master.
-#	-Wshadow \
-
-DEBUG_FLAGS ?= -O3 -g0
-
-CFLAGS ?= $(WARNING_FLAGS) $(DEBUG_FLAGS) -I$(LVGL_DIR)/ -DLVGL_ENV_SIMULATOR=$(LVGL_ENV_SIMULATOR) -fPIC
-LDFLAGS ?=
-LDFLAGS += -lm
-
-PKG_CONFIG ?= pkg-config
-
-REQUIRES = 
-ifeq ($(LVGL_ENV_SIMULATOR), 1)
-CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
-LDFLAGS += $(shell $(PKG_CONFIG) --libs sdl2)
-REQUIRES += sdl2
-else
-CFLAGS += $(shell $(PKG_CONFIG) --cflags libinput)
-LDFLAGS += $(shell $(PKG_CONFIG) --libs libinput)
-REQUIRES += libinput
-
-CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm)
-LDFLAGS += $(shell $(PKG_CONFIG) --libs libdrm)
-
-LDFLAGS += -lpthread
-LDFLAGS += -lxkbcommon
-endif
-
-CFLAGS += $(shell $(PKG_CONFIG) --cflags freetype2)
-LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
-
 # External components
-include $(LVGL_DIR)/lvgl/lvgl.mk
-include $(LVGL_DIR)/lv_drivers/lv_drivers.mk
-include $(LVGL_DIR)/lv_lib_nanosvg/lv_lib_nanosvg.mk
-include $(LVGL_DIR)/lv_lib_freetype/lv_lib_freetype.mk
+include $(LVGL_DIR)/lvgui.mk
 
 ifeq ($(STATIC), true)
 LIBRARY = liblvgui.a
 else
 LIBRARY = liblvgui.so
 endif
-
-# Additional source files
-CSRCS += ./font.c
-CSRCS += ./hal.c
-CSRCS += ./url.c
-CSRCS += ./introspection.c
-CSRCS += ./artwork/lvgui_cursor.c
-CSRCS += ./artwork/lvgui_touch.c
-CSRCS += ./lvgui_struct_accessors.c
-
-CONFFILES = ./lv_conf.h ./lv_drv_conf.h
 
 OBJEXT ?= .o
 

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -282,7 +282,7 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 /*================
  *  THEME USAGE
  *================*/
-#define LV_THEME_LIVE_UPDATE    0   /*1: Allow theme switching at run time. Uses 8..10 kB of RAM*/
+#define LV_THEME_LIVE_UPDATE    1   /*1: Allow theme switching at run time. Uses 8..10 kB of RAM*/
 
 #define LV_USE_THEME_TEMPL      0   /*Just for test*/
 #define LV_USE_THEME_DEFAULT    0   /*Built mainly from the built-in styles. Consumes very few RAM*/

--- a/lv_lib_freetype/lv_lib_freetype.mk
+++ b/lv_lib_freetype/lv_lib_freetype.mk
@@ -1,1 +1,1 @@
-CSRCS += ./lv_lib_freetype/lv_freetype.c
+CSRCS += $(LVGL_DIR)/lv_lib_freetype/lv_freetype.c

--- a/lv_lib_nanosvg/lv_lib_nanosvg.mk
+++ b/lv_lib_nanosvg/lv_lib_nanosvg.mk
@@ -1,1 +1,1 @@
-CSRCS += ./lv_lib_nanosvg/lv_nanosvg.c
+CSRCS += $(LVGL_DIR)/lv_lib_nanosvg/lv_nanosvg.c

--- a/lvgui.mk
+++ b/lvgui.mk
@@ -1,0 +1,91 @@
+LVGL_ENV_SIMULATOR ?= 1
+
+WARNING_FLAGS ?= \
+	-Wall \
+	-Wclobbered \
+	-Wdeprecated \
+	-Wdouble-promotion \
+	-Wempty-body \
+	-Werror \
+	-Wextra \
+	-Wformat-security \
+	-Wmaybe-uninitialized \
+	-Wmissing-prototypes \
+	-Wmultichar \
+	-Wno-cast-qual \
+	-Wno-discarded-qualifiers \
+	-Wno-error=cpp \
+	-Wno-error=missing-prototypes \
+	-Wno-error=pedantic \
+	-Wno-error=strict-prototypes \
+	-Wno-format-nonliteral \
+	-Wno-ignored-qualifiers \
+	-Wno-missing-field-initializers \
+	-Wno-sign-compare \
+	-Wno-switch-default \
+	-Wno-unused-function \
+	-Wno-unused-parameter \
+	-Wno-unused-value \
+	-Wpointer-arith \
+	-Wreturn-type \
+	-Wshift-negative-value \
+	-Wsizeof-pointer-memaccess \
+	-Wstack-usage=4096 \
+	-Wswitch-enum \
+	-Wtype-limits \
+	-Wundef \
+	-Wuninitialized \
+	-Wunreachable-code \
+	-fno-strict-aliasing \
+
+# Fails on master.
+#	-Wshadow \
+
+DEBUG_FLAGS ?= -O3 -g0
+
+CFLAGS += $(WARNING_FLAGS) $(DEBUG_FLAGS)
+CFLAGS += -I$(LVGL_DIR)/
+CFLAGS += -DLVGL_ENV_SIMULATOR=$(LVGL_ENV_SIMULATOR)
+CFLAGS += -fPIC
+CFLAGS += -DVERSION=$(VERSION)
+
+REQUIRES = 
+
+PKG_CONFIG ?= pkg-config
+
+LDFLAGS += -lm
+
+ifeq ($(LVGL_ENV_SIMULATOR), 1)
+CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs sdl2)
+REQUIRES += sdl2
+else
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libinput)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs libinput)
+REQUIRES += libinput
+
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs libdrm)
+
+LDFLAGS += -lpthread
+LDFLAGS += -lxkbcommon
+endif
+
+CFLAGS += $(shell $(PKG_CONFIG) --cflags freetype2)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
+
+CONFFILES += $(LVGL_DIR)/lv_conf.h $(LVGL_DIR)/lv_drv_conf.h
+
+include $(LVGL_DIR)/lvgl/lvgl.mk
+include $(LVGL_DIR)/lv_drivers/lv_drivers.mk
+include $(LVGL_DIR)/lv_lib_nanosvg/lv_lib_nanosvg.mk
+include $(LVGL_DIR)/lv_lib_freetype/lv_lib_freetype.mk
+
+# Additional source files
+CSRCS += $(LVGL_DIR)/font.c
+CSRCS += $(LVGL_DIR)/hal.c
+CSRCS += $(LVGL_DIR)/url.c
+CSRCS += $(LVGL_DIR)/introspection.c
+CSRCS += $(LVGL_DIR)/artwork/lvgui_cursor.c
+CSRCS += $(LVGL_DIR)/artwork/lvgui_touch.c
+CSRCS += $(LVGL_DIR)/lvgui_struct_accessors.c


### PR DESCRIPTION
For using without the mruby-lvgui stuff in Mobile NixOS.

If for any reason some poor old soul wanted to make a C-based app using this toolkit for something else :eyes:...

* * *

Additionally enable live update of themes. Not strictly part of this change set, but used for that other use case :eyes:...

* * *

## TODO

 - [x] Test against Mobile NixOS