### PR TITLE
hal: Fix bad globals definitions

### DIFF
--- a/hal.c
+++ b/hal.c
@@ -11,6 +11,10 @@
 LV_IMG_DECLARE(lvgui_cursor);
 LV_IMG_DECLARE(lvgui_touch);
 
+lv_disp_drv_t disp_drv;
+int mn_hal_default_dpi;
+mn_hal_default_font_t mn_hal_default_font;
+
 static lv_obj_t * lvgui_cursor_obj;
 static lv_obj_t * lvgui_touch_obj;
 static lv_group_t * lvgui_focus_group;

--- a/hal.h
+++ b/hal.h
@@ -4,9 +4,10 @@
 void hal_init(const char* asset_path);
 lv_group_t * lvgui_get_focus_group();
 void lvgui_focus_ring_disable();
-lv_disp_drv_t disp_drv;
-int mn_hal_default_dpi;
-mn_hal_default_font_t mn_hal_default_font;
 char * hal_asset_path(const char* asset_path);
+
+extern lv_disp_drv_t disp_drv;
+extern int mn_hal_default_dpi;
+extern mn_hal_default_font_t mn_hal_default_font;
 
 #endif


### PR DESCRIPTION
They ended-up being defined more than once, which is now caught by an
updated toolchain.

Why it wasn't caught before? I don't know and I hate everything about
that.