### PR TITLE
fbdev: Render 32 bit on 16 bit fbdev

### DIFF
--- a/lv_drivers/display/fbdev.c
+++ b/lv_drivers/display/fbdev.c
@@ -191,6 +191,25 @@ void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color
     }
     /*16 bit per pixel*/
     else if(vinfo.bits_per_pixel == 16) {
+#if LV_COLOR_DEPTH == 32
+        uint16_t * fbp16 = (uint16_t *)fbp;
+        int32_t y;
+        int32_t x;
+		for(y = act_y1; y <= act_y2; y++) {
+			for(x = act_x1; x <= act_x2; x++) {
+                location = (x + vinfo.xoffset) + (y + vinfo.yoffset) * finfo.line_length / 2;
+				fbp16[location] = (uint16_t)(
+					// R, and 3 bits from G
+					((color_p->ch.red   & 0xf8)       | (color_p->ch.green >> 5)) << 8
+					// 3 bits from G, and B
+					| ((color_p->ch.green & 0x1c) << 3) | (color_p->ch.blue  >> 3)
+				);
+				color_p++;
+			}
+
+			color_p += area->x2 - act_x2;
+		}
+#else
         uint16_t * fbp16 = (uint16_t *)fbp;
         int32_t y;
         for(y = act_y1; y <= act_y2; y++) {
@@ -198,6 +217,7 @@ void fbdev_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color
             memcpy(&fbp16[location], (uint32_t *)color_p, (act_x2 - act_x1 + 1) * 2);
             color_p += w;
         }
+#endif
     }
     /*8 bit per pixel*/
     else if(vinfo.bits_per_pixel == 8) {

--- a/lv_drivers/display/fbdev.c
+++ b/lv_drivers/display/fbdev.c
@@ -121,7 +121,15 @@ void fbdev_init(lv_disp_drv_t* disp_drv)
     fbdev_set_resolution(disp_drv);
 
     dbg(
-        "%dx%d, %dbpp,xres_virtual=%d,yres_virtual=%dvinfo.xoffset=%d,vinfo.yoffset=%d\n"
+		"finfo: smem_len=%d, xpanstep=%d, ypanstep=%d, ywrapstep=%d, line_length=%d"
+        , finfo.smem_len
+        , finfo.xpanstep
+        , finfo.ypanstep
+        , finfo.ywrapstep
+        , finfo.line_length
+    );
+    dbg(
+        "vinfo: %dx%d, %dbpp, xres_virtual=%d, yres_virtual=%d, xoffset=%d, yoffset=%d\n"
         , vinfo.xres
         , vinfo.yres
         , vinfo.bits_per_pixel


### PR DESCRIPTION
This was tested on `nokia-argon` with the vendor kernel.

Mainline correctly handles this within DRM, AFAICT.

* * *

Blocked until needed on a system; too cumbersome to keep around without testing.