### PR TITLE
libinput: Fix copy/paste mixup in non-rotated touch.

### DIFF
--- a/lv_drivers/indev/libinput.c
+++ b/lv_drivers/indev/libinput.c
@@ -217,8 +217,8 @@ bool libinput_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 				touch_event = libinput_event_get_touch_event(event);
 				switch (drm_display_orientation) {
 					case DRM_ORIENTATION_NORMAL:
-						instance->root_x = libinput_event_pointer_get_absolute_x_transformed(pointer_event, LV_HOR_RES);
-						instance->root_y = libinput_event_pointer_get_absolute_y_transformed(pointer_event, LV_VER_RES);
+						instance->root_x = libinput_event_touch_get_x_transformed(touch_event, LV_HOR_RES);
+						instance->root_y = libinput_event_touch_get_y_transformed(touch_event, LV_VER_RES);
 						break;
 					case DRM_ORIENTATION_UPSIDE_DOWN:
 						instance->root_x = LV_HOR_RES - libinput_event_touch_get_x_transformed(touch_event, LV_HOR_RES);


### PR DESCRIPTION
Fixes #15

Tested on ASUS TP300LA, which reproduced the issue. The issue is also self-evident in the failure mode and the implementation.

Previous change was only (accidentally) tested with DRM orientation forced to all orientations except normal, since obviously I couldn't have broken the already working implementation, right?

* * *

cc @Luflosi