### PR TITLE
eink improvements

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -288,7 +288,7 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 #define LV_USE_THEME_DEFAULT    0   /*Built mainly from the built-in styles. Consumes very few RAM*/
 #define LV_USE_THEME_ALIEN      0   /*Dark futuristic theme*/
 #define LV_USE_THEME_NIGHT      1   /*Dark elegant theme*/
-#define LV_USE_THEME_MONO       0   /*Mono color theme for monochrome displays*/
+#define LV_USE_THEME_MONO       1   /*Mono color theme for monochrome displays*/
 #define LV_USE_THEME_MATERIAL   0   /*Flat theme with bold colors and light shadows*/
 #define LV_USE_THEME_ZEN        0   /*Peaceful, mainly light theme */
 #define LV_USE_THEME_NEMO       0   /*Water-like theme based on the movie "Finding Nemo"*/


### PR DESCRIPTION
This PR adds two changes improving eink support, but not only eink support:

 - Enables the mono theme
 - Prevents needless "empty" render

The mono theme is basically a pure black and pure white theme, with white being the background. It's basically perfect for eink (though could use thicker border, but eh... It's sufficient)

The other change removes the initial `drmModeSetCrtc`, which would cause a render to happen. It was not generally noticed since it was a single black render on black-background displays. With eink displays requiring a white background, this change was noticeable. The splash screen for Mobile NixOS would really obviously render a black frame on the display.

While this solves mainly the issue for eink displays, this could also be used for providing a fully seamless transition from a previous boot logo. Assuming we can get the framebuffer currently shown to the users, we could do pretty much anything to it, like cross-fade between it and the app. Without getting the framebuffer, on some systems like ACPI with BGRT we can re-constitute the equivalent framebuffer image. It would be possible to use the BGRT in the LVGUI app (e.g. a splash screen) and move it around and do *real fancy stuff*.

These changes, though, are made to support upcoming basic PineNote support in Mobile NixOS.