### PR TITLE
drm: Try all cards

### DIFF
--- a/lv_drv_conf.h
+++ b/lv_drv_conf.h
@@ -219,8 +219,7 @@ extern int monitor_height;
 #endif
 
 #if USE_DRM
-#	define DRM_CARD          "/dev/dri/card0"
-#	define DRM_CONNECTOR_ID  -1	/* -1 for the first connected one */
+/* Nothing to configure */
 #endif
 
 /*********************


### PR DESCRIPTION
On some platforms, e.g. MT8183, the output GPU is not card0. This failed in a way the `fbdev` driver took over, but this means that the intrinsic orientation of the display is not respected.

With this change, all cards will be tried to be used, before then falling back.