### PR TITLE
indev/libinput: Add hotplug support

### DIFF
--- a/lv_drivers/display/drm.c
+++ b/lv_drivers/display/drm.c
@@ -198,7 +198,8 @@ void drm_init(lv_disp_drv_t* drv)
 	info("Starting DRM subsystem...");
 
 	// Ensure that if no paths match, `ret` is non-zero.
-	ret = 1;
+	// Tries to make this fact known with a well-known identifier.
+	ret = 12345;
 
 	// Try opening any of the cards
 	// On some systems (e.g. MT8183), `card0` is not the GPU.
@@ -219,6 +220,9 @@ void drm_init(lv_disp_drv_t* drv)
 
 		// We'll pick the first one available.
 		break;
+	}
+	if (ret == 12345) {
+		info(" -> No DRM card matched.");
 	}
 
 	if (ret) goto err;

--- a/lv_drivers/display/fbdev.c
+++ b/lv_drivers/display/fbdev.c
@@ -115,7 +115,6 @@ void fbdev_init(lv_disp_drv_t* disp_drv)
         perror("Error: failed to map framebuffer device to memory");
         return;
     }
-    memset(fbp, 0, screensize);
 
     print("The framebuffer device was mapped to memory successfully.\n");
 

--- a/lv_drivers/indev/libinput.c
+++ b/lv_drivers/indev/libinput.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <linux/input.h>
+#include <sys/inotify.h>
 #include "../display/drm.h"
 
 #include <xkbcommon/xkbcommon.h>
@@ -86,6 +87,9 @@ static struct xkb_state  *our_xkb_state = NULL;
 static struct xkb_compose_state *our_xkb_compose_state = NULL;
 static int handle_xkbcommon_input(int keycode, int direction, char *key_character, int key_character_length);
 
+static int hotplug_fd;
+static struct pollfd hotplug_fds[1];
+
 static libinput_drv_add_cb_t libinput_drv_add_cb;
 
 /**********************
@@ -132,6 +136,90 @@ bool libinput_set_file(libinput_drv_instance* instance, char* dev_name)
 	return true;
 }
 
+static void libinput_drv_check_devices()
+{
+	// See man inotify(7);
+	char buf[4096] __attribute__ ((aligned(__alignof__(struct inotify_event))));
+	const struct inotify_event *event;
+	ssize_t len;
+
+	int poll_num;
+
+	if (hotplug_fd == -1) { return; }
+
+	poll_num = poll(hotplug_fds, 1, 0);
+	if (poll_num == -1) {
+		if (errno == EINTR) {
+			return;
+		}
+		// On any other error, let's also just return...
+		return;
+	}
+
+	if (!(hotplug_fds[0].revents & POLLIN)) {
+		return;
+	}
+
+	for (;;) {
+		// Read events.
+		len = read(hotplug_fd, buf, sizeof(buf));
+		if (len == -1 && errno != EAGAIN) {
+			perror("read");
+			exit(EXIT_FAILURE);
+		}
+
+		// If the nonblocking read() found no events to read, then
+		// it returns -1 with errno set to EAGAIN. In that case,
+		// we exit the loop.
+		if (len <= 0) {
+			break;
+		}
+
+		// Loop over all events in the buffer.
+		for (char *ptr = buf; ptr < buf + len; ptr += sizeof(struct inotify_event) + event->len) {
+			event = (const struct inotify_event *) ptr;
+			// Seeing a new `event` file?
+			if (
+					!(event->mask & IN_ISDIR)
+					&& event->mask & IN_CREATE
+					&& strncmp(event->name, "event", 5) == 0
+			) {
+				char dev_path[PATH_MAX+1];
+				strncpy(dev_path, "/dev/input/", 12);
+				strncat(dev_path, event->name, PATH_MAX);
+				LVGUI_LOG_INFO("[indev/libinput]: Hot-plugging device %s", dev_path);
+				libinput_init_drv(dev_path);
+			}
+		}
+	}
+}
+
+static void libinput_drv_setup_hotplug()
+{
+	int ret;
+
+	// We're using `inotify` to be notified of new `/dev/input/event*` devices,
+	// rather than relying on libinput's udev support since LVGL requires usage
+	// of one context per device (for the input FD). *sigh*.
+	hotplug_fd = inotify_init();
+
+	if (hotplug_fd == -1) {
+		LVGUI_LOG_WARN("Could not setup inotify for watching /dev/input. (%s)",  strerror(errno));
+		return;
+	}
+
+	hotplug_fds[0].fd = hotplug_fd;
+	hotplug_fds[0].events = POLLIN;
+	hotplug_fds[0].revents = 0;
+	fcntl(hotplug_fd, F_SETFL, O_ASYNC | O_NONBLOCK);
+
+	ret = inotify_add_watch(hotplug_fd, "/dev/input", IN_CREATE);
+	if (ret == -1) {
+		LVGUI_LOG_WARN("Could not watch /dev/input. (%s)",  strerror(errno));
+		hotplug_fd == -1;
+	}
+}
+
 void libinput_drv_init(libinput_drv_add_cb_t callback)
 {
 	char **dev_path;
@@ -140,6 +228,8 @@ void libinput_drv_init(libinput_drv_add_cb_t callback)
 	glob_t globbuf;
 
 	libinput_drv_add_cb = callback;
+
+	libinput_drv_setup_hotplug();
 
 	glob("/dev/input/event*", 0, NULL, &globbuf);
 	for (dev_path = globbuf.gl_pathv, cnt = globbuf.gl_pathc; cnt; dev_path++, cnt--) {
@@ -156,6 +246,8 @@ libinput_drv_instance* libinput_init_drv(char* dev_name)
 	libinput_drv_instance* instance = libinput_drv_instance_new();
 
 	// Assign a fresh context
+	// This is because LVGL's input handling wants to *own* one loop per
+	// device; sharing context means sharing input FDs.
 	instance->libinput_context = libinput_path_create_context(&drv_libinput_interface, NULL);
 
 	if(!libinput_set_file(instance, dev_name)) {
@@ -414,6 +506,8 @@ bool libinput_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 			libinput_device_get_name(instance->libinput_device)
 		);
 	}
+
+	libinput_drv_check_devices();
 
 	// False because there are no events to handle anymore
 	return false;

--- a/lv_drivers/indev/libinput_drv.h
+++ b/lv_drivers/indev/libinput_drv.h
@@ -35,6 +35,9 @@ typedef struct {
 	// Configure this input driver to be a specific LVGL input type.
 	int lv_indev_drv_type;
 
+	// The lvgl input device
+	lv_indev_t * indev;
+
 	// One context per input device.
 	// This is because LVGL's input handling wants to *own* one loop per
 	// device; sharing context means sharing input FDs.
@@ -67,9 +70,16 @@ typedef struct {
  *      TYPEDEFS
  **********************/
 
+typedef void (*libinput_drv_add_cb_t)(libinput_drv_instance* instance);
+
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+
+/**
+ * Starts the libinput driver with the usual defaults.
+ */
+void libinput_drv_init();
 
 /**
  * Initialize a new libinput device instance

--- a/lvgui.mk
+++ b/lvgui.mk
@@ -31,7 +31,7 @@ WARNING_FLAGS ?= \
 	-Wreturn-type \
 	-Wshift-negative-value \
 	-Wsizeof-pointer-memaccess \
-	-Wstack-usage=4096 \
+	-Wstack-usage=8704 \
 	-Wswitch-enum \
 	-Wtype-limits \
 	-Wundef \


### PR DESCRIPTION
With this, it will be possible to drop a hack from Mobile NixOS, and make the startup slightly quicker, but more importantly, much more resilient.

In addition, any lvgui apps benefits from being able to work with input devices connected after the fact.

* * *

Built on top of #20, but only since it will be merged and updated in Mobile NixOS at the same time.