### PR TITLE
lv_ta: Prevent crash on text-free events

### DIFF
--- a/lvgl/src/lv_objx/lv_ta.c
+++ b/lvgl/src/lv_objx/lv_ta.c
@@ -319,6 +319,12 @@ void lv_ta_add_text(lv_obj_t * ta, const char * txt)
     LV_ASSERT_OBJ(ta, LV_OBJX_NAME);
     LV_ASSERT_NULL(txt);
 
+    if (!LV_DEBUG_IS_STR(txt)) {
+        LV_LOG_WARN("lv_ta_add_text() called with invalid string?\n");
+
+        return;
+    }
+
     lv_ta_ext_t * ext = lv_obj_get_ext_attr(ta);
 
     ta_insert_replace = NULL;


### PR DESCRIPTION
It should be considered a bug to send it an empty string, but it is a worserer bug to crash when that happens than to do nothing...

This fixes the issue where fumbling with the modifier keys *could* (but not necessarily!) crash the app.